### PR TITLE
Fix pre-commit hook handling in stop_vibing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ coverage.xml
 
 # Backup files
 *.bak
+*.orig


### PR DESCRIPTION
Fix pre-commit hook handling in stop_vibing

- Add logic to check for changes made by pre-commit hooks after squash commit
- Automatically amend commit if hooks modified files (e.g., formatting changes)
- Ensures final PR commit includes all linting and formatting fixes
- Prevents issues where hook changes are left uncommitted