### PR TITLE
Add integration test for typestate transitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/tests/typestate_integration.rs
+++ b/tests/typestate_integration.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+use tempfile::tempdir;
+use vibe_git::{Idle, VibeSession};
+
+#[test]
+/// Verify MCP-style typestate flow across git branches.
+fn typestate_flow_with_git() {
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(&dir).unwrap();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .status()
+        .unwrap();
+
+    let idle = VibeSession::<Idle>::new("integration-branch");
+    let vibing = idle.start();
+
+    let branch = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(branch.trim(), "integration-branch");
+    assert_eq!(vibing.branch(), "integration-branch");
+
+    let finished = vibing.finish();
+    let branch = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(branch.trim(), "main");
+    assert_eq!(finished.branch(), "integration-branch");
+}


### PR DESCRIPTION
## Summary
- run git checkout in `VibeSession` typestate transitions
- verify branch switching in a temporary git repository via MCP-style integration test
- format source and test files

## Testing
- `cargo fmt --all -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac44c953c8832a8373302ceca44f5e