### PR TITLE
Expose MCP client and improve documentation

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,9 @@
 {
   "mcpServers": {
     "vibe-git": {
-      "command": "uv",
-      "args": ["run", "vibe-git-mcp"],
-      "cwd": "/Users/cgalbreath@simplemachines.co.nz/git/vibe-git"
+      "command": "cargo",
+      "args": ["run", "--bin", "vibe-git-mcp"],
+      "cwd": "."
     }
   }
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,41 @@
 # vibe-git (Rust)
 
-This repository has been rewritten in Rust. It demonstrates typestate programming
-for managing domain state transitions at compile time.
+vibe-git demonstrates typestate programming for managing git workflows. It
+exposes a high-level `McpClient` that drives a `VibeSession` through `Idle`,
+`Vibing`, and `Finished` states while switching branches with real git
+commands.
 
-The core library exposes a `VibeSession` type that moves through `Idle`,
-`Vibing`, and `Finished` states using the type system to prevent invalid
-transitions.
+## Installation
+
+Clone the repository and install the crate locally:
+
+```
+git clone <repo>
+cd vibe-git
+cargo install --path .
+```
+
+You can also use the crate directly in another project by adding it to your
+`Cargo.toml`.
+
+## Usage
+
+Example driving a session via the `McpClient` facade:
+
+```
+use vibe_git::McpClient;
+
+let mut client = McpClient::new();
+client.start_vibing("feature-branch");
+// make code changes on the new branch
+client.stop_vibing();
+```
+
+Run the bundled MCP client binary:
+
+```
+cargo run --bin vibe-git-mcp
+```
 
 ## Development
 

--- a/src/bin/vibe-git-mcp.rs
+++ b/src/bin/vibe-git-mcp.rs
@@ -1,0 +1,36 @@
+use std::io::{self, BufRead};
+use vibe_git::McpClient;
+
+fn main() {
+    let stdin = io::stdin();
+    let mut client = McpClient::new();
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let mut parts = line.split_whitespace();
+        match parts.next() {
+            Some("start") => {
+                if let Some(branch) = parts.next() {
+                    client.start_vibing(branch);
+                    println!("started {branch}");
+                } else {
+                    println!("usage: start <branch>");
+                }
+            }
+            Some("stop") => {
+                client.stop_vibing();
+                println!("stopped");
+            }
+            Some("status") => {
+                if let Some(branch) = client.branch() {
+                    println!("vibing on {branch}");
+                } else {
+                    println!("idle");
+                }
+            }
+            _ => println!("unknown command"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, process::Command};
+
+mod mcp;
+pub use mcp::McpClient;
 
 /// Marker type for the session before it has started.
 pub struct Idle;
@@ -26,6 +29,12 @@ impl VibeSession<Idle> {
 
     /// Start vibing, transitioning to the `Vibing` state.
     pub fn start(self) -> VibeSession<Vibing> {
+        let status = Command::new("git")
+            .args(["checkout", "-b", &self.branch])
+            .status()
+            .expect("failed to run git checkout");
+        assert!(status.success(), "git checkout failed");
+
         VibeSession {
             branch: self.branch,
             state: PhantomData,
@@ -36,6 +45,12 @@ impl VibeSession<Idle> {
 impl VibeSession<Vibing> {
     /// Finish vibing, transitioning to the `Finished` state.
     pub fn finish(self) -> VibeSession<Finished> {
+        let status = Command::new("git")
+            .args(["checkout", "main"])
+            .status()
+            .expect("failed to checkout main");
+        assert!(status.success(), "git checkout main failed");
+
         VibeSession {
             branch: self.branch,
             state: PhantomData,
@@ -58,9 +73,31 @@ impl VibeSession<Finished> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
 
     #[test]
     fn typestate_transitions() {
+        let dir = tempdir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+
+        Command::new("git")
+            .args(["init", "-b", "main"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .status()
+            .unwrap();
+
         let idle = VibeSession::<Idle>::new("feature-branch");
         let vibing = idle.start();
         assert_eq!(vibing.branch(), "feature-branch");

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,39 @@
+use crate::{Idle, VibeSession, Vibing};
+
+/// Simple client API for driving a vibe session.
+pub struct McpClient {
+    session: Option<VibeSession<Vibing>>,
+}
+
+impl McpClient {
+    /// Create a new client with no active session.
+    pub fn new() -> Self {
+        Self { session: None }
+    }
+
+    /// Start vibing on the given branch if not already active.
+    pub fn start_vibing(&mut self, branch: impl AsRef<str>) {
+        if self.session.is_none() {
+            let idle = VibeSession::<Idle>::new(branch.as_ref());
+            self.session = Some(idle.start());
+        }
+    }
+
+    /// Stop the current vibing session if one is active.
+    pub fn stop_vibing(&mut self) {
+        if let Some(vibing) = self.session.take() {
+            let _finished = vibing.finish();
+        }
+    }
+
+    /// Return the active branch name, if any.
+    pub fn branch(&self) -> Option<&str> {
+        self.session.as_ref().map(|s| s.branch())
+    }
+}
+
+impl Default for McpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/mcp_client_integration.rs
+++ b/tests/mcp_client_integration.rs
@@ -1,0 +1,50 @@
+use std::process::Command;
+use tempfile::tempdir;
+use vibe_git::McpClient;
+
+#[test]
+fn mcp_client_switches_branches() {
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(&dir).unwrap();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .status()
+        .unwrap();
+
+    let mut client = McpClient::new();
+    client.start_vibing("integration-branch");
+
+    let branch = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(branch.trim(), "integration-branch");
+
+    client.stop_vibing();
+    let branch = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(branch.trim(), "main");
+}

--- a/tests/typestate_integration.rs
+++ b/tests/typestate_integration.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+use tempfile::tempdir;
+use vibe_git::{Idle, VibeSession};
+
+#[test]
+/// Verify MCP-style typestate flow across git branches.
+fn typestate_flow_with_git() {
+    let dir = tempdir().unwrap();
+    std::env::set_current_dir(&dir).unwrap();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .status()
+        .unwrap();
+
+    let idle = VibeSession::<Idle>::new("integration-branch");
+    let vibing = idle.start();
+
+    let branch = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(branch.trim(), "integration-branch");
+    assert_eq!(vibing.branch(), "integration-branch");
+
+    let finished = vibing.finish();
+    let branch = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    assert_eq!(branch.trim(), "main");
+    assert_eq!(finished.branch(), "integration-branch");
+}


### PR DESCRIPTION
## Summary
- expose simple MCP client and CLI binary
- document installation and usage instructions
- add integration test for MCP client

## Testing
- `cargo fmt --all -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac44c953c8832a8373302ceca44f5e