### PR TITLE
Use cargo build workflow and add crates.io publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --token $CARGO_REGISTRY_TOKEN

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "vibe-git"
 version = "0.1.0"
 edition = "2021"
+description = "Typestate-based git workflow manager with a minimal MCP client"
+license = "MIT"
+repository = "https://github.com/software-is-art/vibe-git"
+readme = "README.md"
+keywords = ["git", "typestate", "workflow"]
+authors = ["Callum Galbreath <37229146+software-is-art@users.noreply.github.com>"]
 
 [dependencies]
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Callum Galbreath
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,17 @@ commands.
 
 ## Installation
 
-Clone the repository and install the crate locally:
+Install from crates.io:
 
 ```
-git clone <repo>
-cd vibe-git
-cargo install --path .
+cargo install vibe-git
+```
+
+If the crate isn't available on crates.io yet or you want the latest code, you
+can install directly from git:
+
+```
+cargo install --git <repo> vibe-git
 ```
 
 You can also use the crate directly in another project by adding it to your
@@ -38,7 +43,21 @@ cargo run --bin vibe-git-mcp
 ```
 
 ## Development
+Ensure you have a recent Rust toolchain installed. Common development tasks:
 
-```
+```bash
+# format code
+cargo fmt --all -- --check
+
+# lint
+cargo clippy --all-targets --all-features -- -D warnings
+
+# run tests
 cargo test
 ```
+
+### Release
+
+Publishing to crates.io is automated via GitHub Actions. Pushing a tag like
+`v0.1.0` will trigger the workflow to run `cargo publish` using the
+`CARGO_REGISTRY_TOKEN` secret.


### PR DESCRIPTION
## Summary
- drop Nix flake and associated tooling
- document cargo-based dev workflow with release instructions
- add GitHub Actions workflow to publish to crates.io on tag

## Testing
- `cargo fmt --all -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6b9b8944832a93c9690cfe6d4e2b