### PR TITLE
feat: add BranchName newtype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,37 @@
-use std::{marker::PhantomData, process::Command};
+use std::{fmt, marker::PhantomData, process::Command};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BranchName(String);
+
+impl BranchName {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for BranchName {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for BranchName {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for BranchName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for BranchName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 mod mcp;
 
@@ -15,13 +48,13 @@ pub struct Finished;
 
 /// A session that transitions through compile-time states.
 pub struct VibeSession<State> {
-    branch: String,
+    branch: BranchName,
     state: PhantomData<State>,
 }
 
 impl VibeSession<Idle> {
     /// Create a new session in the idle state.
-    pub fn new(branch: impl Into<String>) -> Self {
+    pub fn new(branch: impl Into<BranchName>) -> Self {
         Self {
             branch: branch.into(),
             state: PhantomData,
@@ -31,7 +64,7 @@ impl VibeSession<Idle> {
     /// Start vibing, transitioning to the `Vibing` state.
     pub fn start(self) -> VibeSession<Vibing> {
         let status = Command::new("git")
-            .args(["checkout", "-b", &self.branch])
+            .args(["checkout", "-b", self.branch.as_ref()])
             .status()
             .expect("failed to run git checkout");
         assert!(status.success(), "git checkout failed");
@@ -59,14 +92,14 @@ impl VibeSession<Vibing> {
     }
 
     /// Access the active branch name.
-    pub fn branch(&self) -> &str {
+    pub fn branch(&self) -> &BranchName {
         &self.branch
     }
 }
 
 impl VibeSession<Finished> {
     /// Access the branch name after completion.
-    pub fn branch(&self) -> &str {
+    pub fn branch(&self) -> &BranchName {
         &self.branch
     }
 }
@@ -102,8 +135,8 @@ mod tests {
 
         let idle = VibeSession::<Idle>::new("feature-branch");
         let vibing = idle.start();
-        assert_eq!(vibing.branch(), "feature-branch");
+        assert_eq!(vibing.branch().as_ref(), "feature-branch");
         let finished = vibing.finish();
-        assert_eq!(finished.branch(), "feature-branch");
+        assert_eq!(finished.branch().as_ref(), "feature-branch");
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,4 +1,4 @@
-use crate::{Idle, VibeSession, Vibing};
+use crate::{BranchName, Idle, VibeSession, Vibing};
 
 /// Simple client API for driving a vibe session.
 pub struct McpClient {
@@ -12,9 +12,9 @@ impl McpClient {
     }
 
     /// Start vibing on the given branch if not already active.
-    pub fn start_vibing(&mut self, branch: impl AsRef<str>) {
+    pub fn start_vibing(&mut self, branch: impl Into<BranchName>) {
         if self.session.is_none() {
-            let idle = VibeSession::<Idle>::new(branch.as_ref());
+            let idle = VibeSession::<Idle>::new(branch);
             self.session = Some(idle.start());
         }
     }
@@ -27,7 +27,7 @@ impl McpClient {
     }
 
     /// Return the active branch name, if any.
-    pub fn branch(&self) -> Option<&str> {
+    pub fn branch(&self) -> Option<&BranchName> {
         self.session.as_ref().map(|s| s.branch())
     }
 }

--- a/tests/typestate_integration.rs
+++ b/tests/typestate_integration.rs
@@ -37,7 +37,7 @@ fn typestate_flow_with_git() {
     )
     .unwrap();
     assert_eq!(branch.trim(), "integration-branch");
-    assert_eq!(vibing.branch(), "integration-branch");
+    assert_eq!(vibing.branch().as_ref(), "integration-branch");
 
     let finished = vibing.finish();
     let branch = String::from_utf8(
@@ -49,5 +49,5 @@ fn typestate_flow_with_git() {
     )
     .unwrap();
     assert_eq!(branch.trim(), "main");
-    assert_eq!(finished.branch(), "integration-branch");
+    assert_eq!(finished.branch().as_ref(), "integration-branch");
 }


### PR DESCRIPTION
## Summary
- introduce `BranchName` newtype to give branch names semantic meaning
- wire `BranchName` through `VibeSession` and `McpClient`
- update typestate integration tests for the new type

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b18f9bdfd4832abc6886b1d9cd9d0f